### PR TITLE
Handle pyproject.toml with no `source`

### DIFF
--- a/src/poetry_to_uv/convertor.py
+++ b/src/poetry_to_uv/convertor.py
@@ -148,7 +148,10 @@ class PoetryToUv:
         pyproject_config.add("project", tool_poetry)
 
         # Remove the Poetry formatted dependencies.
-        pyproject_config.get("project").remove("source")
+        try:
+            pyproject_config.get("project").remove("source")
+        except NonExistentKey:
+            pass
         try:
             pyproject_config.get("project").remove("group")
         except NonExistentKey:


### PR DESCRIPTION
Hi! Thank you for the project.

This is a change I had to make locally to `poetry_to_uv` for it to continue after not finding a `source`.

```
Traceback (most recent call last):
  File "~/projects/project/.venv/bin/poetry_to_uv", line 8, in <module>
    sys.exit(cli_entrypoint())
  File "~/projects/project/.venv/lib/python3.10/site-packages/poetry_to_uv/__main__.py", line 35, in cli_entrypoint
    poetry_to_uv()
  File "~/projects/project/.venv/lib/python3.10/site-packages/poetry_to_uv/convertor.py", line 249, in __call__
    pyproject_config = self._convert_poetry_to_uv_pyproject(
  File "~/projects/project/.venv/lib/python3.10/site-packages/poetry_to_uv/convertor.py", line 151, in _convert_poetry_to_uv_pyproject
    pyproject_config.get("project").remove("source")
  File "~/projects/project/.venv/lib/python3.10/site-packages/tomlkit/items.py", line 1473, in remove
    self._value.remove(key)
  File "~/projects/project/.venv/lib/python3.10/site-packages/tomlkit/container.py", line 354, in remove
    raise NonExistentKey(key)
tomlkit.exceptions.NonExistentKey: 'Key "source" does not exist.'
```