### PR TITLE
Improve handling with VCS dependencies

### DIFF
--- a/src/poetry_to_uv/convertor.py
+++ b/src/poetry_to_uv/convertor.py
@@ -185,7 +185,12 @@ class PoetryToUv:
 
         uv_dependencies = tomlkit.array()
         for dependency, version in sorted_main_dependencies.items():
-            uv_dependencies.add_line(f"{dependency} == {version}")
+            if version is None:
+                uv_dependencies.add_line(dependency)
+            elif isinstance(version,str) and version.startswith("git+"):
+                uv_dependencies.add_line(f"{dependency}@{version}")
+            else:
+                uv_dependencies.add_line(f"{dependency} == {version}")
 
         pyproject_config["project"]["dependencies"] = uv_dependencies
 
@@ -212,14 +217,24 @@ class PoetryToUv:
         for dependency_group, dependencies in sorted_group_dependencies.items():
             uv_dependencies = tomlkit.array()
             for dependency, version in dependencies.items():
-                uv_dependencies.add_line(f"{dependency} == {version}")
+                if version is None:
+                    uv_dependencies.add_line(dependency)
+                elif isinstance(version,str) and version.startswith("git+"):
+                    uv_dependencies.add_line(f"{dependency}@{version}")
+                else:
+                    uv_dependencies.add_line(f"{dependency} == {version}")
             all_dependency_groups[dependency_group] = uv_dependencies
 
         # Process the extra dependencies.
         for dependency_group, dependencies in sorted_extra_dependencies.items():
             uv_dependencies = tomlkit.array()
             for dependency, version in dependencies.items():
-                uv_dependencies.add_line(f"{dependency} == {version}")
+                if version is None:
+                    uv_dependencies.add_line(dependency)
+                elif isinstance(version,str) and version.startswith("git+"):
+                    uv_dependencies.add_line(f"{dependency}@{version}")
+                else:
+                    uv_dependencies.add_line(f"{dependency} == {version}")
             all_dependency_groups[dependency_group] = uv_dependencies
 
         pyproject_config["project"]["optional-dependencies"] = tomlkit.item(all_dependency_groups)

--- a/src/poetry_to_uv/poetry.py
+++ b/src/poetry_to_uv/poetry.py
@@ -1,11 +1,14 @@
 import subprocess
 from dataclasses import dataclass
+from logging import getLogger
 from pathlib import Path
 
 from packaging.utils import canonicalize_name
 
 from poetry_to_uv.constants import POETRY_COMMAND
 from poetry_to_uv.typing import PoetryResolvedDependencies
+
+log = getLogger(__name__)
 
 
 @dataclass
@@ -54,7 +57,12 @@ class PoetryDependencyExporter:
                 continue
 
             if "@" in dependency_version:
-                dependency, version = dependency_version.split("@")
+                try:
+                    dependency, version = dependency_version.split("@", maxsplit=1)
+                    dependency = dependency.strip()
+                    version = version.strip()
+                except ValueError as e:
+                    log.info(f'Could not parse {dependency_version} to uv format')
             elif "==" in dependency_version:
                 dependency, version = dependency_version.split("==")
             else:


### PR DESCRIPTION
Just provisional: This was hard-coded and may need adjustments as theoretically `svn`, `hg` (at the very least) are possibilities for VCS pip dependencies.

If you are fine if I revise this, I can take a look at this during the evening / weekends.

Traceback:

```
Traceback (most recent call last):
  File "~/projects/project/.venv/bin/poetry_to_uv", line 8, in <module>
    sys.exit(cli_entrypoint())
  File "~/projects/project/.venv/lib/python3.10/site-packages/poetry_to_uv/__main__.py", line 35, in cli_entrypoint
    poetry_to_uv()
  File "~/projects/project/.venv/lib/python3.10/site-packages/poetry_to_uv/convertor.py", line 234, in __call__
    poetry_resolved_dependencies = self.get_poetry_resolved_dependencies(
  File "~/projects/project/.venv/lib/python3.10/site-packages/poetry_to_uv/convertor.py", line 51, in get_poetry_resolved_dependencies
    return poetry_dependency_exporter.export()
  File "~/projects/project/.venv/lib/python3.10/site-packages/poetry_to_uv/poetry.py", line 76, in export
    return self._process_poetry_export_command(poetry_response.stdout)
  File "~/projects/project/.venv/lib/python3.10/site-packages/poetry_to_uv/poetry.py", line 57, in _process_poetry_export_command
    dependency, version = dependency_version.split("@")
ValueError: too many values to unpack (expected 2)
```